### PR TITLE
イベント駆動アーキテクチャの実装

### DIFF
--- a/CatalogService/src/Application/DomainEventHandlers/CatalogServiceEventHandler.ts
+++ b/CatalogService/src/Application/DomainEventHandlers/CatalogServiceEventHandler.ts
@@ -9,9 +9,12 @@ export class CatalogServiceEventHandler {
   ) {}
 
   register() {
-    this.subscriber.subscribe("CatalogService", (event: Record<sting, any>) => {
-      this.handleDomainEvent(event);
-    });
+    this.subscriber.subscribe(
+      "CatalogService",
+      (event: Record<string, any>) => {
+        this.handleDomainEvent(event);
+      },
+    );
   }
 
   private handleDomainEvent(event: Record<string, any>) {

--- a/CatalogService/src/Application/DomainEventHandlers/CatalogServiceEventHandler.ts
+++ b/CatalogService/src/Application/DomainEventHandlers/CatalogServiceEventHandler.ts
@@ -1,0 +1,30 @@
+import { IDomainEventSubscriber } from "Application/shared/DomainEvent/IDomainEventSubscriber";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class CatalogServiceEventHandler {
+  constructor(
+    @inject("IDomainEventSubscriber")
+    private subscriber: IDomainEventSubscriber,
+  ) {}
+
+  register() {
+    this.subscriber.subscribe("CatalogService", (event: Record<sting, any>) => {
+      this.handleDomainEvent(event);
+    });
+  }
+
+  private handleDomainEvent(event: Record<string, any>) {
+    switch (event.eventType) {
+      case "ReviewCreated": {
+        console.log(
+          `新しいレビューが作成されました。レビューID: ${event.aggregatedId}, 書籍ID: ${event.eventBody.bookId}`,
+        );
+
+        break;
+      }
+
+      // 他のイベントタイプに対する処理もここに追加可能
+    }
+  }
+}

--- a/CatalogService/src/Application/Review/AddReviewService/AddReviewService.ts
+++ b/CatalogService/src/Application/Review/AddReviewService/AddReviewService.ts
@@ -12,6 +12,7 @@ import { ReviewId } from "Domain/models/Review/ReviewId/ReviewId";
 import { ReviewIdentity } from "Domain/models/Review/ReviewIdentity/ReviewIdentity";
 
 import { AddReviewDTO } from "./AddReviewDTO";
+import { IDomainEventPublisher } from "Application/shared/DomainEvent/IDomainEventPublisher";
 
 export type AddReviewCommand = {
   bookId: string;
@@ -29,6 +30,8 @@ export class AddReviewService {
     private bookRepository: IBookRepository,
     @inject("ITransactionManager")
     private transactionManager: ITransactionManager,
+    @inject("IDomainEventPublisher")
+    private domainEventPublisher: IDomainEventPublisher,
   ) {}
 
   async execute(command: AddReviewCommand): Promise<AddReviewDTO> {
@@ -38,7 +41,7 @@ export class AddReviewService {
       throw new Error("書籍が存在しません");
     }
 
-    return await this.transactionManager.begin(async () => {
+    const review = await this.transactionManager.begin(async () => {
       const reviewId = new ReviewId();
       const reviewIdentity = new ReviewIdentity(reviewId);
       const name = new Name(command.name);
@@ -57,13 +60,21 @@ export class AddReviewService {
 
       await this.reviewRepository.save(review);
 
-      return {
-        id: review.reviewId.value,
-        bookId: review.bookId.value,
-        name: review.name.value,
-        rating: review.rating.value,
-        comment: review.comment?.value,
-      };
+      return review;
     });
+
+    const events = review.getDomainEvents();
+    for (const event of events) {
+      this.domainEventPublisher.publish(event);
+    }
+    review.clearDomainEvents();
+
+    return {
+      id: review.reviewId.value,
+      bookId: review.bookId.value,
+      name: review.name.value,
+      rating: review.rating.value,
+      comment: review.comment?.value,
+    };
   }
 }

--- a/CatalogService/src/Application/Review/DeleteReviewService/DeleteReviewService.ts
+++ b/CatalogService/src/Application/Review/DeleteReviewService/DeleteReviewService.ts
@@ -28,6 +28,8 @@ export class DeleteReviewService {
         throw new Error("レビューが存在しません");
       }
 
+      review.delete();
+
       await this.reviewRepository.delete(reviewId);
 
       return review;

--- a/CatalogService/src/Application/Review/DeleteReviewService/DeleteReviewService.ts
+++ b/CatalogService/src/Application/Review/DeleteReviewService/DeleteReviewService.ts
@@ -1,3 +1,4 @@
+import { IDomainEventPublisher } from "Application/shared/DomainEvent/IDomainEventPublisher";
 import { ITransactionManager } from "Application/shared/ITransactionManager";
 import { IReviewRepository } from "Domain/models/Review/IReviewRepository";
 import { ReviewId } from "Domain/models/Review/ReviewId/ReviewId";
@@ -14,10 +15,12 @@ export class DeleteReviewService {
     private reviewRepository: IReviewRepository,
     @inject("ITransactionManager")
     private transactionManager: ITransactionManager,
+    @inject("IDomainEventPublisher")
+    private domainEventPublisher: IDomainEventPublisher,
   ) {}
 
   async execute(command: DeleteReviewCommand): Promise<void> {
-    await this.transactionManager.begin(async () => {
+    const review = await this.transactionManager.begin(async () => {
       const reviewId = new ReviewId(command.reviewId);
       const review = await this.reviewRepository.findById(reviewId);
 
@@ -26,6 +29,14 @@ export class DeleteReviewService {
       }
 
       await this.reviewRepository.delete(reviewId);
+
+      return review;
     });
+
+    const events = review.getDomainEvents();
+    for (const event of events) {
+      this.domainEventPublisher.publish(event);
+    }
+    review.clearDomainEvents();
   }
 }

--- a/CatalogService/src/Application/Review/EditReviewService/EditReviewService.ts
+++ b/CatalogService/src/Application/Review/EditReviewService/EditReviewService.ts
@@ -8,6 +8,7 @@ import { Rating } from "Domain/models/Review/Rating/Rating";
 import { ReviewId } from "Domain/models/Review/ReviewId/ReviewId";
 
 import { EditReviewDTO } from "./EditReviewDTO";
+import { IDomainEventPublisher } from "Application/shared/DomainEvent/IDomainEventPublisher";
 
 export type EditReviewCommand = {
   reviewId: string;
@@ -23,10 +24,12 @@ export class EditReviewService {
     private reviewRepository: IReviewRepository,
     @inject("ITransactionManager")
     private transactionManager: ITransactionManager,
+    @inject("IDomainEventPublisher")
+    private domainEbentPublisher: IDomainEventPublisher,
   ) {}
 
   async execute(command: EditReviewCommand): Promise<EditReviewDTO> {
-    return await this.transactionManager.begin(async () => {
+    const review = await this.transactionManager.begin(async () => {
       const reviewId = new ReviewId(command.reviewId);
       const review = await this.reviewRepository.findById(reviewId);
 
@@ -51,13 +54,21 @@ export class EditReviewService {
 
       await this.reviewRepository.update(review);
 
-      return {
-        id: review.reviewId.value,
-        bookId: review.bookId.value,
-        name: review.name.value,
-        rating: review.rating.value,
-        comment: review.comment?.value,
-      };
+      return review;
     });
+
+    const events = review.getDomainEvents();
+    for (const event of events) {
+      this.domainEbentPublisher.publish(event);
+    }
+    review.clearDomainEvents();
+
+    return {
+      id: review.reviewId.value,
+      bookId: review.bookId.value,
+      name: review.name.value,
+      rating: review.rating.value,
+      comment: review.comment?.value,
+    };
   }
 }

--- a/CatalogService/src/Application/shared/DomainEvent/IDomainEventPublisher.ts
+++ b/CatalogService/src/Application/shared/DomainEvent/IDomainEventPublisher.ts
@@ -1,0 +1,5 @@
+import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
+
+export interface IDomainEventPublisher {
+  publish(domainEvent: DomainEvent): void;
+}

--- a/CatalogService/src/Application/shared/DomainEvent/IDomainEventSubscriber.ts
+++ b/CatalogService/src/Application/shared/DomainEvent/IDomainEventSubscriber.ts
@@ -1,0 +1,6 @@
+export interface IDomainEventSubscriber {
+  subscribe(
+    topic: string,
+    callback: (event: Record<string, any>) => void,
+  ): void;
+}

--- a/CatalogService/src/Application/shared/DomainEvent/MockDomainEventPublisher.ts
+++ b/CatalogService/src/Application/shared/DomainEvent/MockDomainEventPublisher.ts
@@ -1,0 +1,10 @@
+import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
+import { IDomainEventPublisher } from "./IDomainEventPublisher";
+
+export class MockDomainEventPublisher implements IDomainEventPublisher {
+  private publishedEvents: DomainEvent[] = [];
+
+  publish(domainEvent: DomainEvent): void {
+    this.publishedEvents.push(domainEvent);
+  }
+}

--- a/CatalogService/src/Domain/models/Review/Review.ts
+++ b/CatalogService/src/Domain/models/Review/Review.ts
@@ -6,9 +6,12 @@ import { Rating } from "./Rating/Rating";
 import { ReviewId } from "./ReviewId/ReviewId";
 import { ReviewIdentity } from "./ReviewIdentity/ReviewIdentity";
 import { Aggregate } from "Domain/shared/Aggregate";
-import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
+import {
+  ReviewDomainEvent,
+  ReviewEventFactory,
+} from "Domain/shared/DomainEvent/ReviewDomainEventFactory";
 
-export class Review extends Aggregate<DomainEvent> {
+export class Review extends Aggregate<ReviewDomainEvent> {
   private constructor(
     private readonly _identity: ReviewIdentity,
     private readonly _bookId: BookId,
@@ -26,7 +29,16 @@ export class Review extends Aggregate<DomainEvent> {
     rating: Rating,
     comment?: Comment,
   ): Review {
-    return new Review(identity, bookId, name, rating, comment);
+    const review = new Review(identity, bookId, name, rating, comment);
+    const event = ReviewEventFactory.createReviewCreated(
+      identity.reviewId,
+      bookId,
+      name,
+      rating,
+      comment,
+    );
+    review.addDomainEvent(event);
+    return review;
   }
 
   static reconstruct(
@@ -102,14 +114,34 @@ export class Review extends Aggregate<DomainEvent> {
   }
 
   updateName(name: Name): void {
+    const event = ReviewEventFactory.createReviewNameUpdated(
+      this.reviewId,
+      name,
+    );
+    this.addDomainEvent(event);
     this._name = name;
   }
 
   updateRating(rating: Rating): void {
+    const event = ReviewEventFactory.createReviewRatingUpdated(
+      this.reviewId,
+      rating,
+    );
+    this.addDomainEvent(event);
     this._rating = rating;
   }
 
   editComment(comment: Comment): void {
+    const event = ReviewEventFactory.createReviewCommentEdited(
+      this.reviewId,
+      comment,
+    );
+    this.addDomainEvent(event);
     this._comment = comment;
+  }
+
+  delete(): void {
+    const event = ReviewEventFactory.createReviewDeleted(this.reviewId);
+    this.addDomainEvent(event);
   }
 }

--- a/CatalogService/src/Domain/models/Review/Review.ts
+++ b/CatalogService/src/Domain/models/Review/Review.ts
@@ -5,15 +5,19 @@ import { Name } from "./Name/Name";
 import { Rating } from "./Rating/Rating";
 import { ReviewId } from "./ReviewId/ReviewId";
 import { ReviewIdentity } from "./ReviewIdentity/ReviewIdentity";
+import { Aggregate } from "Domain/shared/Aggregate";
+import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
 
-export class Review {
+export class Review extends Aggregate<DomainEvent> {
   private constructor(
     private readonly _identity: ReviewIdentity,
     private readonly _bookId: BookId,
     private _name: Name,
     private _rating: Rating,
     private _comment?: Comment,
-  ) {}
+  ) {
+    super();
+  }
 
   static create(
     identity: ReviewIdentity,

--- a/CatalogService/src/Domain/shared/Aggregate.ts
+++ b/CatalogService/src/Domain/shared/Aggregate.ts
@@ -1,0 +1,17 @@
+import { DomainEvent } from "./DomainEvent/DomainEvent";
+
+export abstract class Aggregate<Event extends DomainEvent> {
+  domainEvents: Event[] = [];
+
+  protected addDomainEvent(domainEvent: Event) {
+    this.domainEvents.push(domainEvent);
+  }
+
+  getDomainEvents(): Event[] {
+    return this.domainEvents;
+  }
+
+  clearDomainEvents() {
+    this.domainEvents = [];
+  }
+}

--- a/CatalogService/src/Domain/shared/DomainEvent/DomainEvent.ts
+++ b/CatalogService/src/Domain/shared/DomainEvent/DomainEvent.ts
@@ -1,0 +1,59 @@
+import { nanoid } from "nanoid";
+
+export class DomainEvent<
+  Type extends string = string,
+  Body extends Record<string, unknown> = Record<string, unknown>,
+> {
+  private constructor(
+    // ドメインイベントのID
+    public readonly eventId: string,
+    // 集約のID（書籍ID）
+    public readonly aggregateId: string,
+    // 集約の種類（Book集約など）
+    public readonly aggregateType: string,
+    // ドメインイベントの種類
+    // 作成：{集約名}Created
+    // 更新：{集約名}{項目名}Changed
+    // 追加：{項目名}AddedTo{集約名}
+    // 削除：{項目名}RemovedFrom{集約名}
+    public readonly eventType: Type,
+    // ドメインイベントの内容（イベントに必要な全ての情報）
+    public readonly eventBody: Body,
+    // ドメインイベントの発生時刻
+    public readonly occurredOn: Date,
+  ) {}
+
+  static create<Type extends string, Body extends Record<string, unknown>>(
+    aggregateId: string,
+    aggregateType: string,
+    eventType: Type,
+    eventBody: Body,
+  ): DomainEvent<Type, Body> {
+    return new DomainEvent(
+      nanoid(),
+      aggregateId,
+      aggregateType,
+      eventType,
+      eventBody,
+      new Date(),
+    );
+  }
+
+  static reconstruct<Type extends string, Body extends Record<string, unknown>>(
+    eventId: string,
+    aggregateId: string,
+    aggregateType: string,
+    eventType: Type,
+    eventBody: Body,
+    occurredOn: Date,
+  ): DomainEvent<Type, Body> {
+    return new DomainEvent(
+      eventId,
+      aggregateId,
+      aggregateType,
+      eventType,
+      eventBody,
+      occurredOn,
+    );
+  }
+}

--- a/CatalogService/src/Domain/shared/DomainEvent/ReviewDomainEventFactory.ts
+++ b/CatalogService/src/Domain/shared/DomainEvent/ReviewDomainEventFactory.ts
@@ -1,0 +1,92 @@
+import { ReviewId } from "Domain/models/Review/ReviewId/ReviewId";
+import { DomainEvent } from "./DomainEvent";
+import { BookId } from "Domain/models/Book/BookId/BookId";
+import { Name } from "Domain/models/Review/Name/Name";
+import { Rating } from "Domain/models/Review/Rating/Rating";
+import { Comment } from "Domain/models/Review/Comment/Comment";
+
+type ReviewCreatedEvent = DomainEvent<
+  "ReviewCreated",
+  {
+    reviewId: string;
+    bookId: string;
+    name: string;
+    rating: number;
+    comment?: string;
+  }
+>;
+
+type ReviewNameUpdatedEvent = DomainEvent<
+  "ReviewNameUpdated",
+  { name: string }
+>;
+
+type ReviewRatingUpdatedEvent = DomainEvent<
+  "ReviewRatingUpdated",
+  { rating: number }
+>;
+
+type ReviewCommentEditedEvent = DomainEvent<
+  "ReviewCommentEdited",
+  {
+    comment?: string;
+  }
+>;
+
+type ReviewDeletedEvent = DomainEvent<"ReviewDeleted", Record<string, never>>;
+
+export type ReviewDomainEvent =
+  | ReviewCreatedEvent
+  | ReviewNameUpdatedEvent
+  | ReviewRatingUpdatedEvent
+  | ReviewCommentEditedEvent
+  | ReviewDeletedEvent;
+
+export class ReciewEventFactory {
+  static createReviewCreated(
+    reviewId: ReviewId,
+    bookId: BookId,
+    name: Name,
+    rating: Rating,
+    comment?: Comment,
+  ): ReviewCreatedEvent {
+    return DomainEvent.create(reviewId.value, "Review", "ReviewCreated", {
+      reviewId: reviewId.value,
+      bookId: bookId.value,
+      name: name.value,
+      rating: rating.value,
+      comment: comment?.value,
+    });
+  }
+
+  static createReviewNameUpdated(
+    reviewId: ReviewId,
+    name: Name,
+  ): ReviewNameUpdatedEvent {
+    return DomainEvent.create(reviewId.value, "Review", "ReviewNameUpdated", {
+      name: name.value,
+    });
+  }
+
+  static createReviewRatingUpdated(
+    reviewId: ReviewId,
+    rating: Rating,
+  ): ReviewRatingUpdatedEvent {
+    return DomainEvent.create(reviewId.value, "Review", "ReviewRatingUpdated", {
+      rating: rating.value,
+    });
+  }
+
+  static createReviewCommentEdited(
+    reviewId: ReviewId,
+    comment?: Comment,
+  ): ReviewCommentEditedEvent {
+    return DomainEvent.create(reviewId.value, "Review", "ReviewCommentEdited", {
+      comment: comment?.value,
+    });
+  }
+
+  static createReviewDeleted(reviewId: ReviewId): ReviewDeletedEvent {
+    return DomainEvent.create(reviewId.value, "Review", "ReviewDeleted", {});
+  }
+}

--- a/CatalogService/src/Domain/shared/DomainEvent/ReviewDomainEventFactory.ts
+++ b/CatalogService/src/Domain/shared/DomainEvent/ReviewDomainEventFactory.ts
@@ -42,7 +42,7 @@ export type ReviewDomainEvent =
   | ReviewCommentEditedEvent
   | ReviewDeletedEvent;
 
-export class ReciewEventFactory {
+export class ReviewEventFactory {
   static createReviewCreated(
     reviewId: ReviewId,
     bookId: BookId,

--- a/CatalogService/src/Infrastructure/EventEmitter/EventEmitterClient.ts
+++ b/CatalogService/src/Infrastructure/EventEmitter/EventEmitterClient.ts
@@ -1,0 +1,3 @@
+import EventEmitter from "events";
+
+export const eventEmitterClient = new EventEmitter();

--- a/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventPublisher.ts
+++ b/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventPublisher.ts
@@ -1,7 +1,10 @@
+import { injectable } from "tsyringe";
+
 import { IDomainEventPublisher } from "Application/shared/DomainEvent/IDomainEventPublisher";
 import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
 import { eventEmitterClient } from "./EventEmitterClient";
 
+@injectable()
 export class EventEmitterDomainEventPublisher implements IDomainEventPublisher {
   publish(domainEvent: DomainEvent): void {
     eventEmitterClient.emit("CatalogService", domainEvent);

--- a/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventPublisher.ts
+++ b/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventPublisher.ts
@@ -1,0 +1,9 @@
+import { IDomainEventPublisher } from "Application/shared/DomainEvent/IDomainEventPublisher";
+import { DomainEvent } from "Domain/shared/DomainEvent/DomainEvent";
+import { eventEmitterClient } from "./EventEmitterClient";
+
+export class EventEmitterDomainEventPublisher implements IDomainEventPublisher {
+  publish(domainEvent: DomainEvent): void {
+    eventEmitterClient.emit("CatalogService", domainEvent);
+  }
+}

--- a/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventSubscriber.ts
+++ b/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventSubscriber.ts
@@ -1,6 +1,9 @@
+import { injectable } from "tsyringe";
+
 import { IDomainEventSubscriber } from "Application/shared/DomainEvent/IDomainEventSubscriber";
 import { eventEmitterClient } from "./EventEmitterClient";
 
+@injectable()
 export class EventEmitterDomainEventSubscriber implements IDomainEventSubscriber {
   subscribe(
     topic: string,

--- a/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventSubscriber.ts
+++ b/CatalogService/src/Infrastructure/EventEmitter/EventEmitterDomainEventSubscriber.ts
@@ -1,0 +1,11 @@
+import { IDomainEventSubscriber } from "Application/shared/DomainEvent/IDomainEventSubscriber";
+import { eventEmitterClient } from "./EventEmitterClient";
+
+export class EventEmitterDomainEventSubscriber implements IDomainEventSubscriber {
+  subscribe(
+    topic: string,
+    callback: (event: Record<string, any>) => void,
+  ): void {
+    eventEmitterClient.on(topic, callback);
+  }
+}

--- a/CatalogService/src/Infrastructure/SQL/SQLClientManager.ts
+++ b/CatalogService/src/Infrastructure/SQL/SQLClientManager.ts
@@ -1,9 +1,10 @@
 import { AsyncLocalStorage } from "async_hooks";
 import { PoolClient } from "pg";
+import { injectable } from "tsyringe";
 
 import pool from "./db";
 
-
+@injectable()
 export class SQLClientManager {
     // コンテキスト(現在の接続)を保持するストレージ
     private asyncLocalStorage = new AsyncLocalStorage<PoolClient>();

--- a/CatalogService/src/Presentation/Express/index.ts
+++ b/CatalogService/src/Presentation/Express/index.ts
@@ -24,6 +24,7 @@ import {
 } from "Application/Review/GetRecommendedBooksService/GetRecommendedBooksService";
 
 import "../../Program";
+import { CatalogServiceEventHandler } from "Application/DomainEventHandlers/CatalogServiceEventHandler";
 
 const app = express();
 const port = 3000;
@@ -138,4 +139,7 @@ app.delete("/review/:reviewId", async (req, res) => {
 
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
+
+  // サブスクライバーを登録
+  container.resolve(CatalogServiceEventHandler).register();
 });

--- a/CatalogService/src/Program.ts
+++ b/CatalogService/src/Program.ts
@@ -19,7 +19,7 @@ container.register("ITransactionManager", {
 });
 
 // DomainEvent
-container.register("IDmainEvenPulisher", {
+container.register("IDomainEventPublisher", {
   useClass: EventEmitterDomainEventPublisher,
 });
 

--- a/CatalogService/src/Program.ts
+++ b/CatalogService/src/Program.ts
@@ -3,6 +3,8 @@ import { container } from "tsyringe";
 import { SQLBookRepository } from "Infrastructure/SQL/Book/SQLBookRepository";
 import { SQLReviewRepository } from "Infrastructure/SQL/Review/SQLReviewRepository";
 import { SQLTransactionManager } from "Infrastructure/SQL/SQLTransactionManager";
+import { EventEmitterDomainEventPublisher } from "Infrastructure/EventEmitter/EventEmitterDomainEventPublisher";
+import { EventEmitterDomainEventSubscriber } from "Infrastructure/EventEmitter/EventEmitterDomainEventSubscriber";
 
 container.register("IBookRepository", {
   useClass: SQLBookRepository,
@@ -14,4 +16,13 @@ container.register("IReviewRepository", {
 
 container.register("ITransactionManager", {
   useClass: SQLTransactionManager,
+});
+
+// DomainEvent
+container.register("IDmainEvenPulisher", {
+  useClass: EventEmitterDomainEventPublisher,
+});
+
+container.register("IDomainEventSubscriber", {
+  useClass: EventEmitterDomainEventSubscriber,
 });

--- a/CatalogService/src/TestProgram.ts
+++ b/CatalogService/src/TestProgram.ts
@@ -1,3 +1,4 @@
+import { MockDomainEventPublisher } from "Application/shared/DomainEvent/MockDomainEventPublisher";
 import { MockTransactionManager } from "Application/shared/MockTransactionManager";
 import { InMemoryBookRepository } from "Infrastructure/InMemory/Book/InMemoryBookRepository";
 import { InMemoryReviewRepository } from "Infrastructure/InMemory/Review/InMemoryReviewRepository";
@@ -13,4 +14,8 @@ container.register("IReviewRepository", {
 
 container.register("ITransactionManager", {
   useClass: MockTransactionManager,
+});
+
+container.register("IDomainEventPublisher", {
+  useClass: MockDomainEventPublisher,
 });


### PR DESCRIPTION
- **feat: ドメインイベントの定義 #22**
- **feat: ドメインイベント記録用のクラスを作成 #22**
- **feat: ReviewDomainEventのファクトリーメソッドを定義 #22**
- **feat: 集約においてドメインイベントを登録するように定義 #22**
- **feat: ドメインイベントのパブリッシャーのインターフェイスを作成 #22**
- **feat: ドメインイベントのサブスクライバーのインターフェイスを定義 #22**
- **feat: Emitterインスタンスを共有するためのファイルを定義 #22**
- **feat: パブリッシャーの定義 #22**
- **feat: サブスクライバーの定義 #22**
- **feat: ドメインイベントのインターフェイスの依存関係をDIコンテナで制御 #22**
- **feat: アプリケーションサービス内でドメインイベントをpublishするように変更 #22**
- **feat: テストでもドメインイベントの内容をテストできるように変更 #22**
- **feat: レビュー修正機能にドメインイベントをpublishするように変更 #22**
- **feat: レビュー削除機能にドメインイベントをpublishするように変更 #22**
- **feat: レビュー集約に関するドメインイベントのsubscribeの定義 #22**
- **feat: subscribeの依存関係を解決 #22**
- **fix: DIコンテナの設定に必要なデコレーターの指定ミスを修正 #22**

fix: #22 